### PR TITLE
docs: enhance Braintrust AI SDK integration guide with detailed Next.js and Node.js examples

### DIFF
--- a/content/providers/05-observability/braintrust.mdx
+++ b/content/providers/05-observability/braintrust.mdx
@@ -9,47 +9,143 @@ Braintrust is an end-to-end platform for building AI applications. When building
 
 ## Setup
 
-### OpenTelemetry
+Braintrust natively supports OpenTelemetry and works out of the box with the AI SDK, either via Next.js or Node.js.
 
-Braintrust supports [AI SDK telemetry data](/docs/ai-sdk-core/telemetry).
-To set up Braintrust as an [OpenTelemetry](https://opentelemetry.io/docs/) backend, you'll need to route the traces to Braintrust's OpenTelemetry endpoint, set your API key, and specify a parent project or experiment.
+### Next.js
 
-Once you set up an [OpenTelemetry Protocol Exporter](https://opentelemetry.io/docs/languages/js/exporters/) (OTLP) to send traces to Braintrust, we automatically convert LLM calls into Braintrust `LLM` spans, which can be saved as [prompts](https://www.braintrust.dev/docs/guides/functions/prompts) and evaluated in the [playground](https://www.braintrust.dev/docs/guides/playground).
+If you are using Next.js, you can use the Braintrust exporter with `@vercel/otel` for the cleanest setup:
 
-To use the AI SDK to send telemetry data to Braintrust, set these environment variables in your Next.js app's `.env` file:
+```typescript
+import { registerOTel } from "@vercel/otel";
+import { BraintrustExporter } from "braintrust";
 
-```bash
+// In your instrumentation.ts file
+export function register() {
+  registerOTel({
+    serviceName: "my-braintrust-app",
+    traceExporter: new BraintrustExporter({
+      parent: "project_name:your-project-name",
+      filterAISpans: true, // Only send AI-related spans
+    }),
+  });
+}
+```
+
+Or set the following environment variables in your app's `.env` file, with your API key and project ID:
+
+```
 OTEL_EXPORTER_OTLP_ENDPOINT=https://api.braintrust.dev/otel
 OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer <Your API Key>, x-bt-parent=project_id:<Your Project ID>"
 ```
 
-You can then use the `experimental_telemetry` option to enable telemetry on supported AI SDK function calls:
+Traced LLM calls will appear under the Braintrust project or experiment provided in the `x-bt-parent` header.
+
+When you call the AI SDK, make sure to set `experimental_telemetry`:
 
 ```typescript
-import { createOpenAI } from '@ai-sdk/openai';
-import { generateText } from 'ai';
+const result = await generateText({
+  model: openai("gpt-4o-mini"),
+  prompt: "What is 2 + 2?",
+  experimental_telemetry: {
+    isEnabled: true,
+    metadata: {
+      query: "weather",
+      location: "San Francisco",
+    },
+  },
+});
+```
 
-const openai = createOpenAI();
+<Note>
+The integration supports streaming functions like `streamText`. Each streamed call will produce `ai.streamText` spans in Braintrust.
+
+```typescript
+import { openai } from "@ai-sdk/openai";
+import { streamText } from "ai";
+
+export async function POST(req: Request) {
+  const { prompt } = await req.json();
+
+  const result = await streamText({
+    model: openai("gpt-4o-mini"),
+    prompt,
+    experimental_telemetry: { isEnabled: true },
+  });
+
+  return result.toDataStreamResponse();
+}
+```
+</Note>
+
+### Node.js
+
+If you are using Node.js without a framework, you must configure the `NodeSDK` directly. Here, it's more straightforward to use the `BraintrustSpanProcessor`.
+
+First, install the necessary dependencies:
+
+```bash
+npm install ai @ai-sdk/openai braintrust @opentelemetry/sdk-node @opentelemetry/sdk-trace-base zod
+```
+
+Then, set up the OpenTelemetry SDK:
+
+```typescript
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import { generateText, tool } from "ai";
+import { openai } from "@ai-sdk/openai";
+import { z } from "zod";
+import { BraintrustSpanProcessor } from "braintrust";
+
+const sdk = new NodeSDK({
+  spanProcessors: [
+    new BraintrustSpanProcessor({
+      parent: "project_name:your-project-name",
+      filterAISpans: true,
+    }),
+  ],
+});
+
+sdk.start();
 
 async function main() {
   const result = await generateText({
-    model: openai('gpt-4o-mini'),
-    prompt: 'What is 2 + 2?',
+    model: openai("gpt-4o-mini"),
+    messages: [
+      {
+        role: "user",
+        content: "What are my orders and where are they? My user ID is 123",
+      },
+    ],
+    tools: {
+      listOrders: tool({
+        description: "list all orders",
+        parameters: z.object({ userId: z.string() }),
+        execute: async ({ userId }) =>
+          `User ${userId} has the following orders: 1`,
+      }),
+      viewTrackingInformation: tool({
+        description: "view tracking information for a specific order",
+        parameters: z.object({ orderId: z.string() }),
+        execute: async ({ orderId }) =>
+          `Here is the tracking information for ${orderId}`,
+      }),
+    },
     experimental_telemetry: {
       isEnabled: true,
+      functionId: "my-awesome-function",
       metadata: {
-        query: 'weather',
-        location: 'San Francisco',
+        something: "custom",
+        someOtherThing: "other-value",
       },
     },
+    maxSteps: 10,
   });
-  console.log(result);
+
+  await sdk.shutdown();
 }
 
-main();
+main().catch(console.error);
 ```
-
-Traced LLM calls will appear under the Braintrust project or experiment provided in the `x-bt-parent` header.
 
 ## Resources
 

--- a/content/providers/05-observability/braintrust.mdx
+++ b/content/providers/05-observability/braintrust.mdx
@@ -9,13 +9,6 @@ Braintrust is an end-to-end platform for building AI applications. When building
 
 ## Setup
 
-Braintrust offers two approaches for integrating with the AI SDK:
-
-1. **OpenTelemetry (OTel)**: Standards-based tracing that works with your existing observability infrastructure
-2. **Native Braintrust Wrapper**: Direct integration providing granular control and seamless access to Braintrust features
-
-Choose the approach that best fits your project's needs and existing infrastructure.
-
 ### OpenTelemetry
 
 Braintrust supports [AI SDK telemetry data](/docs/ai-sdk-core/telemetry).
@@ -57,81 +50,6 @@ main();
 ```
 
 Traced LLM calls will appear under the Braintrust project or experiment provided in the `x-bt-parent` header.
-
-### Native Braintrust Wrapper
-
-As an alternative to OpenTelemetry, you can use Braintrust's native wrapper to automatically log your AI SDK requests. This approach provides more granular control over tracing and seamless integration with Braintrust's features.
-
-```typescript
-import { initLogger, wrapAISDKModel } from 'braintrust';
-import { openai } from '@ai-sdk/openai';
-import { generateText } from 'ai';
-
-// Initialize the Braintrust logger
-initLogger({
-  projectName: 'My Project',
-  apiKey: process.env.BRAINTRUST_API_KEY,
-});
-
-// Wrap the AI SDK model
-const model = wrapAISDKModel(openai('gpt-4o-mini'));
-
-async function main() {
-  // This will automatically log the request, response, and metrics to Braintrust
-  const result = await generateText({
-    model: model,
-    prompt: 'What is the capital of France?',
-  });
-  
-  console.log(result.text);
-}
-
-main();
-```
-
-#### Wrapping Tools
-
-You can also wrap tool implementations to log their executions:
-
-```typescript
-import { wrapTraced } from 'braintrust';
-import { tool } from 'ai';
-import { z } from 'zod';
-
-const weatherTool = wrapTraced(
-  tool({
-    description: 'Get the current weather for a location',
-    parameters: z.object({
-      location: z.string().describe('The location to get weather for'),
-    }),
-    execute: async ({ location }) => {
-      // Your tool implementation
-      return {
-        temperature: 72,
-        condition: 'sunny',
-        location,
-      };
-    },
-  }),
-  {
-    name: 'weather_tool',
-  }
-);
-```
-
-## Choosing Between OpenTelemetry and Native Wrapper
-
-- **Use OpenTelemetry** if you:
-  - Have existing OpenTelemetry infrastructure
-  - Want standards-based tracing
-  - Need to send traces to multiple backends
-  - Prefer minimal code changes
-
-- **Use Native Wrapper** if you:
-  - Want granular control over tracing
-  - Need tight integration with Braintrust features
-  - Want to wrap specific models or tools
-  - Prefer explicit logging control
 
 ## Resources
 

--- a/content/providers/05-observability/braintrust.mdx
+++ b/content/providers/05-observability/braintrust.mdx
@@ -79,7 +79,7 @@ export async function POST(req: Request) {
 
 ### Node.js
 
-If you are using Node.js without a framework, you must configure the `NodeSDK` directly. Here, it's more straightforward to use the `BraintrustSpanProcessor`.
+If you are using Node.js without a framework, you must configure the `NodeSDK` directly. In this case, it's more straightforward to use the `BraintrustSpanProcessor`.
 
 First, install the necessary dependencies:
 

--- a/content/providers/05-observability/braintrust.mdx
+++ b/content/providers/05-observability/braintrust.mdx
@@ -9,6 +9,13 @@ Braintrust is an end-to-end platform for building AI applications. When building
 
 ## Setup
 
+Braintrust offers two approaches for integrating with the AI SDK:
+
+1. **OpenTelemetry (OTel)**: Standards-based tracing that works with your existing observability infrastructure
+2. **Native Braintrust Wrapper**: Direct integration providing granular control and seamless access to Braintrust features
+
+Choose the approach that best fits your project's needs and existing infrastructure.
+
 ### OpenTelemetry
 
 Braintrust supports [AI SDK telemetry data](/docs/ai-sdk-core/telemetry).
@@ -51,39 +58,80 @@ main();
 
 Traced LLM calls will appear under the Braintrust project or experiment provided in the `x-bt-parent` header.
 
-### Model Wrapping
+### Native Braintrust Wrapper
 
-You can wrap AI SDK models in Braintrust to automatically log your requests.
+As an alternative to OpenTelemetry, you can use Braintrust's native wrapper to automatically log your AI SDK requests. This approach provides more granular control over tracing and seamless integration with Braintrust's features.
 
 ```typescript
 import { initLogger, wrapAISDKModel } from 'braintrust';
 import { openai } from '@ai-sdk/openai';
+import { generateText } from 'ai';
 
-const logger = initLogger({
+// Initialize the Braintrust logger
+initLogger({
   projectName: 'My Project',
   apiKey: process.env.BRAINTRUST_API_KEY,
 });
 
-const model = wrapAISDKModel(openai.chat('gpt-3.5-turbo'));
+// Wrap the AI SDK model
+const model = wrapAISDKModel(openai('gpt-4o-mini'));
 
 async function main() {
   // This will automatically log the request, response, and metrics to Braintrust
-  const response = await model.doGenerate({
-    mode: {
-      type: 'regular',
-    },
-    prompt: [
-      {
-        role: 'user',
-        content: [{ type: 'text', text: 'What is the capital of France?' }],
-      },
-    ],
+  const result = await generateText({
+    model: model,
+    prompt: 'What is the capital of France?',
   });
-  console.log(response);
+  
+  console.log(result.text);
 }
 
 main();
 ```
+
+#### Wrapping Tools
+
+You can also wrap tool implementations to log their executions:
+
+```typescript
+import { wrapTraced } from 'braintrust';
+import { tool } from 'ai';
+import { z } from 'zod';
+
+const weatherTool = wrapTraced(
+  tool({
+    description: 'Get the current weather for a location',
+    parameters: z.object({
+      location: z.string().describe('The location to get weather for'),
+    }),
+    execute: async ({ location }) => {
+      // Your tool implementation
+      return {
+        temperature: 72,
+        condition: 'sunny',
+        location,
+      };
+    },
+  }),
+  {
+    name: 'weather_tool',
+  }
+);
+```
+
+## Choosing Between OpenTelemetry and Native Wrapper
+
+- **Use OpenTelemetry** if you:
+  - Have existing OpenTelemetry infrastructure
+  - Want standards-based tracing
+  - Need to send traces to multiple backends
+  - Prefer minimal code changes
+
+- **Use Native Wrapper** if you:
+  - Want granular control over tracing
+  - Need tight integration with Braintrust features
+  - Want to wrap specific models or tools
+  - Prefer explicit logging control
 
 ## Resources
 


### PR DESCRIPTION
## Summary
- Removes the detailed example code for Braintrust's native wrapper integration with the AI SDK
- Adds comprehensive setup instructions for Braintrust with OpenTelemetry in Next.js and Node.js environments
- Includes updated example code snippets for telemetry-enabled AI SDK calls and streaming support
- Simplifies the guide by focusing on OpenTelemetry integration and removing the native wrapper code snippet

## Changes

### Documentation Updates
- Deleted the "Model Wrapping" section that included TypeScript example for wrapping AI SDK models
- Added detailed Next.js setup using `@vercel/otel` and Braintrust exporter
- Added Node.js setup instructions with `NodeSDK` and `BraintrustSpanProcessor` for telemetry
- Updated example code to demonstrate telemetry options and streaming function usage
- Maintained references to OpenTelemetry integration and general setup instructions

## Test plan
- Verified documentation renders correctly without the removed native wrapper section
- Confirmed new example code snippets and instructions are clear, syntactically correct, and comprehensive
- Reviewed content for clarity and completeness after removal of native wrapper example and addition of new setup instructions

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/6536a32e-fefc-4c27-9118-c3c58b6a021b